### PR TITLE
Additional styling

### DIFF
--- a/src/app/components/IdeaCard.tsx
+++ b/src/app/components/IdeaCard.tsx
@@ -12,10 +12,10 @@ export const IdeaCard = ({
     deleteCard?: (id: number) => void
   }) => {
 
-  const buttonStyle = 'min-h-8 min-w-8 rounded-lg bg-pink-200 text-purple-700 hover:bg-pink-500 hover:text-purple-900 flex items-center justify-center'
+  const buttonStyle = 'min-h-8 min-w-8 rounded-lg bg-pink-200 text-purple-700 hover:bg-pink-500 hover:text-purple-900 flex items-center justify-center hover:shadow-md hover:shadow-pink-700'
 
   return (
-    <div className='min-h-32 w-32 bg-purple-400 rounded-lg m-2 p-2'>
+    <div className='min-h-32 w-32 bg-purple-400 rounded-lg m-2 p-2 border-2 border-purple-700'>
       <div className='flex justify-between'>
         {favoriteCard && <button 
           onClick={() => favoriteCard(card.id)}

--- a/src/app/components/IdeaForm.tsx
+++ b/src/app/components/IdeaForm.tsx
@@ -29,7 +29,7 @@ export const IdeaForm = ({
   };
 
   return (
-    <div className='w-72 h-600 p-6 bg-pink-400 rounded-xl '>
+    <div className='w-72 h-600 p-6 bg-pink-400 rounded-xl border-2 border-purple-600'>
       <div className='w-full h-32 flex flex-col items-center justify-center'>
         <input 
         className='my-2 p-2 rounded-xl hover:bg-pink-200 text-pink-800'

--- a/src/app/favorites/page.tsx
+++ b/src/app/favorites/page.tsx
@@ -21,6 +21,7 @@ const Favorites = () => {
     <div className='flex flex-col items-center justify-center'>
       <h1>Favorites Page!</h1>
       <Link className='h-8 min-w-1/2 m-4 p-1 cursor-pointer rounded-lg bg-purple-300 text-purple-700 hover:bg-pink-300' href='/'>Go Home!</Link>
+      <Link className='h-8 min-w-1/2 m-4 p-1 cursor-pointer rounded-lg bg-purple-300 text-purple-700 hover:bg-pink-300' href='/request'>Go to /request</Link>
 
       <div className='flex max-w-lg flex-wrap items-center justify-center'>
         {favorites.length ? JSON.parse(favorites || '').map((card: Card) => <IdeaCard key={card.id} card={card}/>) : <></>}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -94,8 +94,8 @@ export default function Home() {
         {isFilteredByFavorites ? 'Show All Ideas' : 'Filter By Favorites'} 
       </button>}
 
-      <Link href='/favorites' className='h-8 min-w-1/2 m-4 p-1 cursor-pointer rounded-lg bg-purple-300 text-purple-700 hover:bg-pink-300'>Go To /favorites</Link>
-      <Link href='/request' className='h-8 min-w-1/2 m-4 p-1 cursor-pointer rounded-lg bg-purple-300 text-purple-700 hover:bg-pink-300'>Go To /request</Link>
+      <Link href='/favorites' className='h-8 min-w-1/2 m-4 p-1 cursor-pointer rounded-lg bg-purple-300 text-purple-700 hover:bg-pink-300 hover:shadow-md hover:shadow-pink-700'>Go To /favorites</Link>
+      <Link href='/request' className='h-8 min-w-1/2 m-4 p-1 cursor-pointer rounded-lg bg-purple-300 text-purple-700 hover:bg-pink-300 hover:shadow-md hover:shadow-pink-700'>Go To /request</Link>
 
       <div className='flex max-w-lg flex-wrap items-center justify-center'>
          {displayCards.length > 0 && displayCards.map((card: Card) => <IdeaCard key={card.id} card={card} favoriteCard={favoriteCard} deleteCard={deleteCard}/>)}

--- a/src/app/request/page.tsx
+++ b/src/app/request/page.tsx
@@ -16,13 +16,14 @@ export default async function RequestPage() {
   return (
     <div className='flex flex-col items-center justify-center'>
       <h1>This is the request page!</h1>
-      <Link className='h-8 min-w-1/2 m-4 p-1 cursor-pointer rounded-lg bg-purple-300 text-purple-700 hover:bg-pink-300' href='/'>Go Home!</Link>
-      <Link href='/favorites' className='h-8 min-w-1/2 m-4 p-1 cursor-pointer rounded-lg bg-purple-300 text-purple-700 hover:bg-pink-300'>Go To /favorites</Link>
+      <Link className='h-8 min-w-1/2 m-4 p-1 cursor-pointer rounded-lg bg-purple-300 text-purple-700 hover:bg-pink-300 hover:shadow-md hover:shadow-pink-700' href='/'>Go Home!</Link>
+      <Link href='/favorites' className='h-8 min-w-1/2 m-4 p-1 cursor-pointer rounded-lg bg-purple-300 text-purple-700 hover:bg-pink-300 hover:shadow-md hover:shadow-pink-700'>Go To /favorites</Link>
       <Image
         src={data[0].url}
         alt='cat'
         height={data[0].height}
         width={data[0].width}
+        className='max-w-72 max-h-72 rounded-lg'
       />
     </div>
   );


### PR DESCRIPTION
This PR takes care of some smaller styling enhancements to satisfy some more learning goals 
- styles Next Image component (pass in actual height and width, but downsize using Tailwind)
- Adds box shadow on hover to most buttons for some educational fun
- Adds borders to idea cards and the form to split up the space a little
- Adds /request link to /favorites page

Most of these changes were meant to satisfy learning goals rather than improved UX, so they're not the prettiest, but they sure do work! 

<img width="758" alt="Screenshot 2025-01-09 at 11 32 22 AM" src="https://github.com/user-attachments/assets/ca3406ee-e100-46ab-86ed-1b05cbc39821" />

<img width="551" alt="Screenshot 2025-01-09 at 11 32 11 AM" src="https://github.com/user-attachments/assets/a032c803-57c7-402b-98a6-47c9d9de8843" />

<img width="311" alt="Screenshot 2025-01-09 at 11 34 07 AM" src="https://github.com/user-attachments/assets/1a94b77c-7733-486d-8868-19b1df7db67e" />
