### PR TITLE
Re-request cat photos

### DIFF
--- a/src/app/components/ConfirmationDialog.tsx
+++ b/src/app/components/ConfirmationDialog.tsx
@@ -1,0 +1,26 @@
+export const ConfirmationDialog = ({
+  clearCards,
+  setOpen
+} : {
+  clearCards: () => void
+  setOpen: (state: boolean) => void
+}) => {
+ return (
+    <div className='bg-opacity-80 bg-purple-900 h-screen w-screen z-index-50 absolute m-0 flex flex-col items-center justify-center'>
+      <div className='h-24 w-72 rounded-xl flex flex-col items-center justify-center bg-purple-600 text-pink-300 border-2 border-purple-900'>
+        Are you sure?
+        <div className='flex items-center justify-center'>
+          <button 
+            className='h-8 min-w-1/2 m-4 p-1 cursor-pointer rounded-lg bg-purple-300 text-purple-700 hover:bg-pink-300 hover:shadow-md hover:shadow-pink-700'
+            onClick={() => setOpen(false)}>No</button>
+          <button 
+            className='h-8 min-w-1/2 m-4 p-1 cursor-pointer rounded-lg bg-purple-300 text-purple-700 hover:bg-pink-300 hover:shadow-md hover:shadow-pink-700'
+            onClick={clearCards}
+          >
+            Yes
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+};

--- a/src/app/favorites/page.tsx
+++ b/src/app/favorites/page.tsx
@@ -10,7 +10,6 @@ const Favorites = () => {
   if (typeof window !== undefined) {
     try {
     favorites = localStorage.getItem('favorites') || '';
-    const cards = localStorage.getItem('cards');
     } catch(e) {
       console.log(e)
     }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,7 +5,6 @@ import { IdeaCard } from "./components/IdeaCard";
 import { Card, findCard } from "@/utils";
 import Link from "next/link";
 import { ConfirmationDialog } from "./components/ConfirmationDialog";
-import { clear } from "console";
 
 export default function Home() {
   const [cards, setCards] = useState<Card[] | []>([]);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -99,22 +99,24 @@ export default function Home() {
       <h1 className='m-1 text-xl text-bold'>Ideabox!</h1>
       <IdeaForm saveCard={saveCard}/>
 
+      <div className='flex items-center justify-center'>
       {cards.length > 0 && <button 
         onClick={filterFavorites}
-        className = {`h-8 min-w-1/2 m-4 p-1 cursor-pointer rounded-lg ${isFilteredByFavorites ? 'bg-pink-300 text-pink-700 hover:bg-purple-300' : 'bg-purple-300 text-purple-700 hover:bg-pink-300'}`}
+        className = {`min-h-8 min-w-1/2 m-4 p-1 cursor-pointer rounded-lg ${isFilteredByFavorites ? 'bg-pink-300 text-pink-700 hover:bg-purple-300' : 'bg-purple-300 text-purple-700 hover:bg-pink-300'}`}
       >
         {isFilteredByFavorites ? 'Show All Ideas' : 'Filter By Favorites'} 
       </button>}
 
       {cards.length > 0 && <button 
         onClick={() => setIsDialogOpen(true)}
-        className = 'h-8 min-w-1/2 m-4 p-1 cursor-pointer rounded-lg bg-purple-300 text-purple-700 hover:bg-pink-300 hover:shadow-md hover:shadow-pink-700'
+        className = 'min-h-8 min-w-1/2 m-4 p-1 cursor-pointer rounded-lg bg-purple-300 text-purple-700 hover:bg-pink-300 hover:shadow-md hover:shadow-pink-700'
       >
         Clear all cards
       </button>}
 
-      <Link href='/favorites' className='h-8 min-w-1/2 m-4 p-1 cursor-pointer rounded-lg bg-purple-300 text-purple-700 hover:bg-pink-300 hover:shadow-md hover:shadow-pink-700'>Go To /favorites</Link>
-      <Link href='/request' className='h-8 min-w-1/2 m-4 p-1 cursor-pointer rounded-lg bg-purple-300 text-purple-700 hover:bg-pink-300 hover:shadow-md hover:shadow-pink-700'>Go To /request</Link>
+      <Link href='/favorites' className='min-h-8 min-w-1/2 m-4 p-1 cursor-pointer rounded-lg bg-purple-300 text-purple-700 hover:bg-pink-300 hover:shadow-md hover:shadow-pink-700'>Go To /favorites</Link>
+      <Link href='/request' className='min-h-8 min-w-1/2 m-4 p-1 cursor-pointer rounded-lg bg-purple-300 text-purple-700 hover:bg-pink-300 hover:shadow-md hover:shadow-pink-700'>Go To /request</Link>
+      </div>
 
       <div className='flex max-w-lg flex-wrap items-center justify-center'>
          {displayCards.length > 0 && displayCards.map((card: Card) => <IdeaCard key={card.id} card={card} favoriteCard={favoriteCard} deleteCard={deleteCard}/>)}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,11 +4,14 @@ import { IdeaForm } from "./components/IdeaForm";
 import { IdeaCard } from "./components/IdeaCard";
 import { Card, findCard } from "@/utils";
 import Link from "next/link";
+import { ConfirmationDialog } from "./components/ConfirmationDialog";
+import { clear } from "console";
 
 export default function Home() {
   const [cards, setCards] = useState<Card[] | []>([]);
   const [ displayCards, setDisplayCards ] = useState<Card[]>([]);
   const [ isFilteredByFavorites, setIsFilteredByFavorites ] = useState<boolean>(false);
+  const [ isDialogOpen, setIsDialogOpen ] = useState<boolean>(false);
 
   useEffect(() => {
 
@@ -79,6 +82,15 @@ export default function Home() {
   const filterFavorites = () => {
     setIsFilteredByFavorites(!isFilteredByFavorites);
   };
+
+  const clearCards = () => {
+    if (typeof window !== undefined) {
+      localStorage.setItem('cards', '');
+      setCards([]);
+      setDisplayCards([]);
+      setIsDialogOpen(false);
+    }
+  }
   
   return (
     <div 
@@ -94,12 +106,20 @@ export default function Home() {
         {isFilteredByFavorites ? 'Show All Ideas' : 'Filter By Favorites'} 
       </button>}
 
+      {cards.length > 0 && <button 
+        onClick={() => setIsDialogOpen(true)}
+        className = 'h-8 min-w-1/2 m-4 p-1 cursor-pointer rounded-lg bg-purple-300 text-purple-700 hover:bg-pink-300 hover:shadow-md hover:shadow-pink-700'
+      >
+        Clear all cards
+      </button>}
+
       <Link href='/favorites' className='h-8 min-w-1/2 m-4 p-1 cursor-pointer rounded-lg bg-purple-300 text-purple-700 hover:bg-pink-300 hover:shadow-md hover:shadow-pink-700'>Go To /favorites</Link>
       <Link href='/request' className='h-8 min-w-1/2 m-4 p-1 cursor-pointer rounded-lg bg-purple-300 text-purple-700 hover:bg-pink-300 hover:shadow-md hover:shadow-pink-700'>Go To /request</Link>
 
       <div className='flex max-w-lg flex-wrap items-center justify-center'>
          {displayCards.length > 0 && displayCards.map((card: Card) => <IdeaCard key={card.id} card={card} favoriteCard={favoriteCard} deleteCard={deleteCard}/>)}
        </div>
+       {isDialogOpen && <ConfirmationDialog setOpen={setIsDialogOpen} clearCards={clearCards} />}
     </div>
   );
 };

--- a/src/app/request/page.tsx
+++ b/src/app/request/page.tsx
@@ -19,6 +19,9 @@ export default async function RequestPage() {
     } catch (e) {
       console.error(e) 
 
+      // the catch value is technically an unknown, so before checking any data
+      // you first need to check if its an instance of the Error object for type safety
+      
       if (e instanceof Error && e.message === 'Failed to fetch cat data') {
         const response = await fetch('https://api.thecatapi.com/v1/images/search', {
           cache: 'no-store'

--- a/src/app/request/page.tsx
+++ b/src/app/request/page.tsx
@@ -26,6 +26,7 @@ export default async function RequestPage() {
         className='max-w-72 max-h-72 rounded-lg'
       />
       <Link 
+        className='h-8 min-w-1/2 m-4 p-1 cursor-pointer rounded-lg bg-purple-300 text-purple-700 hover:bg-pink-300 hover:shadow-md hover:shadow-pink-700'
         href='/request'
       >
         Give me another cat!

--- a/src/app/request/page.tsx
+++ b/src/app/request/page.tsx
@@ -21,7 +21,7 @@ export default async function RequestPage() {
 
       if (e instanceof Error && e.message === 'Failed to fetch cat data') {
         const response = await fetch('https://api.thecatapi.com/v1/images/search', {
-          cache: 'no-store', // Disable caching for fresh data
+          cache: 'no-store'
         });
   
         if (!response.ok) {

--- a/src/app/request/page.tsx
+++ b/src/app/request/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 
 export default async function RequestPage() {
 
-  const fetchKitty = async () => {
+  const getCatPhoto = async () => {
     try {
 
       const response = await fetch('https://api.thecatapi.com/v1/images/search', {
@@ -35,7 +35,8 @@ export default async function RequestPage() {
     }
   }
 
-  const data = await fetchKitty()
+  const catPhoto = await getCatPhoto()
+  const {url, height, width} = catPhoto[0]
 
   return (
     <div className='flex flex-col items-center justify-center'>
@@ -43,10 +44,10 @@ export default async function RequestPage() {
       <Link className='h-8 min-w-1/2 m-4 p-1 cursor-pointer rounded-lg bg-purple-300 text-purple-700 hover:bg-pink-300 hover:shadow-md hover:shadow-pink-700' href='/'>Go Home!</Link>
       <Link href='/favorites' className='h-8 min-w-1/2 m-4 p-1 cursor-pointer rounded-lg bg-purple-300 text-purple-700 hover:bg-pink-300 hover:shadow-md hover:shadow-pink-700'>Go To /favorites</Link>
       <Image
-        src={data[0].url}
+        src={url}
         alt='cat'
-        height={data[0].height}
-        width={data[0].width}
+        height={height}
+        width={width}
         className='max-w-72 max-h-72 rounded-lg'
       />
       <Link 

--- a/src/app/request/page.tsx
+++ b/src/app/request/page.tsx
@@ -25,6 +25,11 @@ export default async function RequestPage() {
         width={data[0].width}
         className='max-w-72 max-h-72 rounded-lg'
       />
+      <Link 
+        href='/request'
+      >
+        Give me another cat!
+      </Link>
     </div>
   );
 };

--- a/src/app/request/page.tsx
+++ b/src/app/request/page.tsx
@@ -14,19 +14,28 @@ export default async function RequestPage() {
         throw new Error('Failed to fetch cat data');
       }
 
-      return response
+      return await response.json()
 
     } catch (e) {
       console.error(e) 
-      const response = await fetch('https://api.thecatapi.com/v1/images/search', {
-        cache: 'no-store', // Disable caching for fresh data
-      });
+
+      if (e instanceof Error && e.message === 'Failed to fetch cat data') {
+        const response = await fetch('https://api.thecatapi.com/v1/images/search', {
+          cache: 'no-store', // Disable caching for fresh data
+        });
+  
+        if (!response.ok) {
+          console.error('Failed to re-fetch cat data');
+          return
+        }
+
+        return await response.json();
+      }
       
-      return response;
     }
   }
 
-  const data = await (await fetchKitty()).json()
+  const data = await fetchKitty()
 
   return (
     <div className='flex flex-col items-center justify-center'>

--- a/src/app/request/page.tsx
+++ b/src/app/request/page.tsx
@@ -3,15 +3,30 @@ import Link from "next/link";
 
 export default async function RequestPage() {
 
-  const response = await fetch('https://api.thecatapi.com/v1/images/search', {
-    cache: 'no-store', // Disable caching for fresh data
-  });
+  const fetchKitty = async () => {
+    try {
 
-  if (!response.ok) {
-    throw new Error('Failed to fetch cat data');
+      const response = await fetch('https://api.thecatapi.com/v1/images/search', {
+        cache: 'no-store', // Disable caching for fresh data
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to fetch cat data');
+      }
+
+      return response
+
+    } catch (e) {
+      console.error(e) 
+      const response = await fetch('https://api.thecatapi.com/v1/images/search', {
+        cache: 'no-store', // Disable caching for fresh data
+      });
+      
+      return response;
+    }
   }
 
-  const data = await response.json();
+  const data = await (await fetchKitty()).json()
 
   return (
     <div className='flex flex-col items-center justify-center'>

--- a/src/app/request/page.tsx
+++ b/src/app/request/page.tsx
@@ -12,16 +12,16 @@ export default async function RequestPage() {
 
       if (!response.ok) {
         throw new Error('Failed to fetch cat data');
-      }
+      };
 
-      return await response.json()
+      return await response.json();
 
     } catch (e) {
-      console.error(e) 
+      console.error(e);
 
       // the catch value is technically an unknown, so before checking any data
       // you first need to check if its an instance of the Error object for type safety
-      
+
       if (e instanceof Error && e.message === 'Failed to fetch cat data') {
         const response = await fetch('https://api.thecatapi.com/v1/images/search', {
           cache: 'no-store'
@@ -29,17 +29,17 @@ export default async function RequestPage() {
   
         if (!response.ok) {
           console.error('Failed to re-fetch cat data');
-          return
-        }
+          return;
+        };
 
         return await response.json();
       }
       
-    }
-  }
+    };
+  };
 
-  const catPhoto = await getCatPhoto()
-  const {url, height, width} = catPhoto[0]
+  const catPhoto = await getCatPhoto();
+  const {url, height, width} = catPhoto[0];
 
   return (
     <div className='flex flex-col items-center justify-center'>


### PR DESCRIPTION
## Re-request cat images
But it's not really a button. Since server components can't allow interaction with the client's browser (the thing that contains the event object that buttons listen for in their onClick functions), for this use case it seemed like it would work to just add a static link back to `/request` to re-request the image, but it's basically a hard refresh of this page. 

It's not necessarily ideal, and of course in a larger app the API layer would be sending the fetched image url to the browser when rendering the image. This solution works for this small of an application because the `/request` page isn't doing much, there aren't analytics that are triggered falsely on page load, or a bunch of other useEffects that are called from different interactions happening. 

This is a pretty small PR, but it taught me how client and server components can't be combined. I can't fetch an image using a server component and nest it inside of a client component unfortunately. 
These server components serve up secure and static data, and only by MacGuyvering a link into a button did this idea work, obvs not the best for accessibility but tabbing through this page still works which is also interesting! 

Sometimes this cat api returns bad data, so I added a 1-time recursive function to re-request data in case it errors out. Instead of an early return in the catch block, I would prefer to throw another error to the parent function, but I don't think that's necessary in an app of this size. 


## Clear cards

Now a user can clear all their cards from the local storage and app state caches with a cute little confirmation dialog

<img width="685" alt="Screenshot 2025-01-10 at 10 31 02 AM" src="https://github.com/user-attachments/assets/1bb1da52-229e-441c-99c4-5665e612b42e" />

<img width="994" alt="Screenshot 2025-01-10 at 10 31 58 AM" src="https://github.com/user-attachments/assets/eefda67b-a36d-4588-af07-9853c9ab25ef" />
