### PR TITLE
Dockerize app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:18
+
+# The WORKDIR sets the context for subsequent commands. You can name it whatever you like
+WORKDIR /app 
+
+# Copy package.json and package-lock.json
+COPY package*.json ./
+
+# Install all dependencies
+RUN npm install
+
+# Copy all the code from our project (current root directory) to our WORKDIR
+COPY . .
+
+# Tells the container that out app runs on the port 3000
+EXPOSE 3000
+
+# Ask the container to start the development server
+CMD npm run dev

--- a/next.config.ts
+++ b/next.config.ts
@@ -14,6 +14,7 @@ const nextConfig: NextConfig = {
       },
     ],
   },
+  output: 'standalone',
 };
 
 export default nextConfig;


### PR DESCRIPTION
This pr adds a Dockerfile to this app to containerize it for "scalable deployment to cloud computing services" 

Use this by: 
- Ensuring Docker app is installed on your machine 
- Running `docker build -t next-15-idea-box .` (don't forget the period!) in root to build
- Running `docker run -p 3000:3000 next-15-idea-box` to run the app 

References this [article](https://medium.com/@itsuki.enjoy/dockerize-a-next-js-app-4b03021e084d)